### PR TITLE
feat(config): add deterministic config resolution precedence

### DIFF
--- a/src/common/config/__init__.py
+++ b/src/common/config/__init__.py
@@ -1,6 +1,13 @@
 """Configuration loading utilities."""
 
-from .loader import AppConfig, MissionConfig, TrustConfig, load_app_config, load_yaml_file
+from .loader import (
+    AppConfig,
+    MissionConfig,
+    TrustConfig,
+    load_app_config,
+    load_yaml_file,
+    resolve_app_config,
+)
 
 __all__ = [
     "AppConfig",
@@ -8,4 +15,5 @@ __all__ = [
     "TrustConfig",
     "load_app_config",
     "load_yaml_file",
+    "resolve_app_config",
 ]

--- a/src/common/config/loader.py
+++ b/src/common/config/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from dataclasses import dataclass
 from math import isfinite
@@ -61,8 +62,35 @@ def load_yaml_file(path: str | Path) -> dict[str, Any]:
 
 
 def load_app_config(path: str | Path) -> AppConfig:
-    payload = load_yaml_file(path)
-    return _validate_app_config(payload, Path(path))
+    return resolve_app_config(path)
+
+
+def resolve_app_config(
+    base_path: str | Path,
+    scenario_override_path: str | Path | None = None,
+    cli_override_path: str | Path | None = None,
+) -> AppConfig:
+    payload = resolve_app_config_payload(
+        base_path=base_path,
+        scenario_override_path=scenario_override_path,
+        cli_override_path=cli_override_path,
+    )
+    return _validate_app_config(payload, Path(base_path))
+def resolve_app_config_payload(
+    base_path: str | Path,
+    scenario_override_path: str | Path | None = None,
+    cli_override_path: str | Path | None = None,
+) -> dict[str, Any]:
+    payload = load_yaml_file(base_path)
+    payload = _apply_config_override(
+        payload,
+        scenario_override_path,
+    )
+    payload = _apply_config_override(
+        payload,
+        cli_override_path,
+    )
+    return payload
 
 
 def _validate_app_config(payload: dict[str, Any], source_path: Path) -> AppConfig:
@@ -118,6 +146,61 @@ def _validate_app_config(payload: dict[str, Any], source_path: Path) -> AppConfi
     )
 
 
+def _apply_config_override(
+    base_payload: dict[str, Any],
+    override_path: str | Path | None,
+) -> dict[str, Any]:
+    if override_path is None:
+        return base_payload
+
+    override_payload = load_yaml_file(override_path)
+    return _merge_config_mappings(
+        base_payload=base_payload,
+        override_payload=override_payload,
+        override_source=Path(override_path),
+        field_path="config",
+    )
+
+
+def _merge_config_mappings(
+    base_payload: dict[str, Any],
+    override_payload: dict[str, Any],
+    override_source: Path,
+    field_path: str,
+) -> dict[str, Any]:
+    merged = deepcopy(base_payload)
+
+    for key, override_value in override_payload.items():
+        current_path = f"{field_path}.{key}"
+        if key not in merged:
+            raise ValueError(
+                f"Unknown config override field in {override_source}: {current_path}"
+            )
+
+        base_value = merged[key]
+        if isinstance(base_value, dict):
+            if not isinstance(override_value, dict):
+                raise ValueError(
+                    f"Config override field {current_path} in {override_source} "
+                    "must remain a mapping."
+                )
+            merged[key] = _merge_config_mappings(
+                base_payload=base_value,
+                override_payload=override_value,
+                override_source=override_source,
+                field_path=current_path,
+            )
+            continue
+
+        if isinstance(override_value, dict):
+            raise ValueError(
+                f"Config override field {current_path} in {override_source} "
+                "must not replace a scalar with a mapping."
+            )
+
+        merged[key] = deepcopy(override_value)
+
+    return merged
 def _require_mapping(value: Any, field_name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{field_name} must be a mapping.")

--- a/src/gnss_trust/main.py
+++ b/src/gnss_trust/main.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
-from common.config import load_app_config
+from common.config import resolve_app_config
 from scenario_orchestrator.manifest_loader import load_manifest
 from scenario_orchestrator.orchestrator import ScenarioOrchestrator
 
@@ -28,10 +28,18 @@ def main() -> int:
         default=str(DEFAULT_CONFIG_PATH),
         help="Path to the simulation config file.",
     )
+    parser.add_argument(
+        "--config-override",
+        help="Optional CLI override config applied after any scenario override.",
+    )
     args = parser.parse_args()
 
-    config = load_app_config(args.config)
     manifest = load_manifest(args.scenario)
+    config = resolve_app_config(
+        base_path=args.config,
+        scenario_override_path=manifest.config_override_path,
+        cli_override_path=args.config_override,
+    )
     snapshot = ScenarioOrchestrator(manifest).build_snapshot()
     assessment = TrustService(config.trust).evaluate(
         snapshot, vio_healthy=not args.vio_unhealthy

--- a/src/mission_continuity/main.py
+++ b/src/mission_continuity/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from common.config import load_app_config
+from common.config import resolve_app_config
 from .state_machine import MissionStateMachine
 
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "sim" / "default.yaml"
@@ -25,9 +25,16 @@ def main() -> int:
         default=str(DEFAULT_CONFIG_PATH),
         help="Path to the simulation config file.",
     )
+    parser.add_argument(
+        "--config-override",
+        help="Optional CLI override config applied after the base config.",
+    )
     args = parser.parse_args()
 
-    config = load_app_config(args.config)
+    config = resolve_app_config(
+        base_path=args.config,
+        cli_override_path=args.config_override,
+    )
     state = MissionStateMachine(config=config.mission).update(
         mission_confidence=args.mission_confidence,
         gnss_state=args.gnss_state,

--- a/src/scenario_orchestrator/main.py
+++ b/src/scenario_orchestrator/main.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
-from common.config import load_app_config
+from common.config import resolve_app_config
 from common.logging import get_logger
 from common.runtime_metadata import resolve_software_revision, utc_timestamp
 from evaluation.artifact_schema import REPORT_SCHEMA_VERSION
@@ -24,12 +24,17 @@ def run_scenario(
     scenario_path: str | Path,
     output_dir: str | Path,
     config_path: str | Path = DEFAULT_CONFIG_PATH,
+    config_override_path: str | Path | None = None,
     run_id: str | None = None,
     vio_healthy: bool = True,
 ) -> dict[str, object]:
     logger = get_logger("scenario_orchestrator.main")
-    config = load_app_config(config_path)
     manifest = load_manifest(scenario_path)
+    config = resolve_app_config(
+        base_path=config_path,
+        scenario_override_path=manifest.config_override_path,
+        cli_override_path=config_override_path,
+    )
     snapshot = ScenarioOrchestrator(manifest).build_snapshot()
     resolved_run_id = run_id or Path(output_dir).name
     software_revision = resolve_software_revision()
@@ -121,6 +126,10 @@ def main() -> int:
         help="Path to the simulation config file.",
     )
     parser.add_argument(
+        "--config-override",
+        help="Optional CLI override config applied after any scenario override.",
+    )
+    parser.add_argument(
         "--run-id",
         help="Optional run identifier written into the evaluation artifacts.",
     )
@@ -130,6 +139,7 @@ def main() -> int:
         scenario_path=args.scenario,
         output_dir=args.output_dir,
         config_path=args.config,
+        config_override_path=args.config_override,
         run_id=args.run_id,
         vio_healthy=not args.vio_unhealthy,
     )

--- a/src/scenario_orchestrator/manifest_loader.py
+++ b/src/scenario_orchestrator/manifest_loader.py
@@ -27,6 +27,7 @@ class ScenarioManifest:
     gnss_condition: str
     run_seed: int
     metadata: dict[str, str]
+    config_override_path: Path | None = None
 
 
 def load_manifest(path: str | Path) -> ScenarioManifest:
@@ -79,6 +80,10 @@ def _validate_manifest(payload: dict[str, Any], source_path: Path) -> ScenarioMa
         raise ValueError("run_seed must be non-negative.")
 
     metadata = _parse_metadata(payload["metadata"])
+    config_override_path = _parse_config_override_path(
+        payload.get("config_override"),
+        source_path,
+    )
 
     return ScenarioManifest(
         scenario_id=scenario_id,
@@ -88,6 +93,7 @@ def _validate_manifest(payload: dict[str, Any], source_path: Path) -> ScenarioMa
         gnss_condition=gnss_condition,
         run_seed=run_seed,
         metadata=metadata,
+        config_override_path=config_override_path,
     )
 
 
@@ -125,3 +131,21 @@ def _parse_metadata(value: Any) -> dict[str, str]:
         metadata[field_name] = field_value
 
     return metadata
+
+
+def _parse_config_override_path(value: Any, source_path: Path) -> Path | None:
+    if value is None:
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError("config_override must be a string path when provided.")
+
+    raw_path = value.strip()
+    if not raw_path:
+        raise ValueError("config_override must not be empty.")
+
+    override_path = Path(raw_path)
+    if not override_path.is_absolute():
+        override_path = source_path.parent / override_path
+
+    return override_path

--- a/tests/unit/test_config_resolution.py
+++ b/tests/unit/test_config_resolution.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from common.config import load_app_config, resolve_app_config
+
+
+BASE_CONFIG = """
+config_id: sim-v1
+schema_version: "1.0"
+trust:
+  quality_weight: 0.8
+  availability_weight: 0.2
+  mission_confidence_weight: 0.75
+  vio_bonus: 0.25
+  denied_outage_ratio_threshold: 0.8
+  denied_trust_threshold: 0.25
+  degraded_trust_threshold: 0.75
+mission:
+  nominal_confidence_threshold: 0.8
+  degraded_confidence_threshold: 0.5
+  denied_fallback_confidence_threshold: 0.3
+  emergency_land_confidence_threshold: 0.2
+  denied_allowed_states:
+    - MISSION_FALLBACK
+    - MISSION_SAFE_HOLD
+"""
+
+SCENARIO_OVERRIDE = """
+trust:
+  degraded_trust_threshold: 0.6
+mission:
+  degraded_confidence_threshold: 0.45
+"""
+
+CLI_OVERRIDE = """
+trust:
+  degraded_trust_threshold: 0.33
+  vio_bonus: 0.4
+"""
+
+INVALID_OVERRIDE = """
+trust:
+  future_only_field: 1.0
+"""
+
+
+class ConfigResolutionTests(unittest.TestCase):
+    def test_base_only_resolution_matches_base_config(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            base_path = self._write_file(temp_dir, "base.yaml", BASE_CONFIG)
+
+            self.assertEqual(resolve_app_config(base_path), load_app_config(base_path))
+
+    def test_scenario_override_applies_after_base_config(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            base_path = self._write_file(temp_dir, "base.yaml", BASE_CONFIG)
+            scenario_override_path = self._write_file(
+                temp_dir,
+                "scenario-override.yaml",
+                SCENARIO_OVERRIDE,
+            )
+
+            config = resolve_app_config(
+                base_path=base_path,
+                scenario_override_path=scenario_override_path,
+            )
+
+            self.assertEqual(config.trust.degraded_trust_threshold, 0.6)
+            self.assertEqual(config.mission.degraded_confidence_threshold, 0.45)
+            self.assertEqual(config.trust.vio_bonus, 0.25)
+
+    def test_cli_override_takes_precedence_over_scenario_override(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            base_path = self._write_file(temp_dir, "base.yaml", BASE_CONFIG)
+            scenario_override_path = self._write_file(
+                temp_dir,
+                "scenario-override.yaml",
+                SCENARIO_OVERRIDE,
+            )
+            cli_override_path = self._write_file(
+                temp_dir,
+                "cli-override.yaml",
+                CLI_OVERRIDE,
+            )
+
+            config = resolve_app_config(
+                base_path=base_path,
+                scenario_override_path=scenario_override_path,
+                cli_override_path=cli_override_path,
+            )
+
+            self.assertEqual(config.trust.degraded_trust_threshold, 0.33)
+            self.assertEqual(config.trust.vio_bonus, 0.4)
+            self.assertEqual(config.mission.degraded_confidence_threshold, 0.45)
+
+    def test_resolution_rejects_unknown_override_fields(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            base_path = self._write_file(temp_dir, "base.yaml", BASE_CONFIG)
+            invalid_override_path = self._write_file(
+                temp_dir,
+                "invalid-override.yaml",
+                INVALID_OVERRIDE,
+            )
+
+            with self.assertRaisesRegex(ValueError, "Unknown config override field"):
+                resolve_app_config(
+                    base_path=base_path,
+                    scenario_override_path=invalid_override_path,
+                )
+
+    def test_resolution_is_deterministic_for_same_inputs(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            base_path = self._write_file(temp_dir, "base.yaml", BASE_CONFIG)
+            scenario_override_path = self._write_file(
+                temp_dir,
+                "scenario-override.yaml",
+                SCENARIO_OVERRIDE,
+            )
+            cli_override_path = self._write_file(
+                temp_dir,
+                "cli-override.yaml",
+                CLI_OVERRIDE,
+            )
+
+            first = resolve_app_config(
+                base_path=base_path,
+                scenario_override_path=scenario_override_path,
+                cli_override_path=cli_override_path,
+            )
+            second = resolve_app_config(
+                base_path=base_path,
+                scenario_override_path=scenario_override_path,
+                cli_override_path=cli_override_path,
+            )
+
+            self.assertEqual(first, second)
+
+    def _write_file(self, directory: str, name: str, contents: str) -> Path:
+        path = Path(directory) / name
+        path.write_text(contents.lstrip(), encoding="utf-8")
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_manifest_loader.py
+++ b/tests/unit/test_manifest_loader.py
@@ -47,6 +47,38 @@ class ManifestLoaderTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 load_manifest(manifest_path)
 
+    def test_manifest_resolves_relative_config_override_path(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            overrides_dir = Path(temp_dir) / "overrides"
+            overrides_dir.mkdir()
+            manifest_path = Path(temp_dir) / "manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "scenario_id: override_case",
+                        "map_name: test_map",
+                        'vehicle_spawn: {"x": 0.0, "y": 0.0, "z": 10.0}',
+                        "route_waypoints:",
+                        '  - {"x": 1.0, "y": 1.0, "z": 10.0}',
+                        "gnss_condition: nominal",
+                        "run_seed: 1",
+                        "config_override: overrides/scenario.yaml",
+                        "metadata:",
+                        "  title: Override Manifest",
+                        "  description: Manifest with config override path.",
+                        "  owner: test-suite",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = load_manifest(manifest_path)
+
+            self.assertEqual(
+                manifest.config_override_path,
+                overrides_dir / "scenario.yaml",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements `P3-T2 Config resolution precedence` with explicit deterministic precedence:

1. base config
2. scenario override
3. CLI override

This PR centralizes config resolution, keeps override behavior explicit, rejects unknown override fields, and preserves deterministic runtime behavior.

## Changes

- add centralized config resolution in `common.config`
- implement deterministic merge order: base -> scenario -> CLI
- reject unknown override fields instead of silently accepting them
- add optional `config_override` support in scenario manifests
- wire scenario orchestrator, GNSS trust, and mission continuity CLIs to the centralized resolver
- add unit tests for precedence and relative manifest override path resolution

## Scope

This PR is intentionally limited to `P3-T2`.

It does not:
- add canonical config serialization
- add config hashing
- change artifact schema
- change decision authority
- introduce environment-based override sources

## Validation

```bash
PYTHONPATH=src python -m unittest discover -s tests/unit -p 'test_config_resolution.py' -v
PYTHONPATH=src python -m unittest discover -s tests/unit -p 'test_manifest_loader.py' -v
bash scripts/smoke_test.sh
```

Validation passed locally:
- `test_config_resolution.py`: `5/5 OK`
- `test_manifest_loader.py`: `4/4 OK`
- `smoke_test.sh`: `25 tests OK`